### PR TITLE
ENG-86: Add GBP/USD exchange rate alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Daily Price Tracker
 
-A Python-based investment tracker that sends daily summaries and intraday spike/dip alerts for Gold, ISWD, and HBKS via Telegram. Designed to run on a Raspberry Pi via cron.
+A Python-based investment tracker that sends daily summaries and intraday spike/dip alerts for Gold, ISWD, HBKS, and GBP/USD via Telegram. Designed to run on a Raspberry Pi via cron.
 
 ## Features
 
 - **Daily Summary**: Prices in GBP, daily/weekly/monthly trends
-- **Intraday Alerts**: Notifications when assets move beyond configurable thresholds
+- **Intraday Alerts**: Notifications when assets or GBP/USD move beyond configurable thresholds
 - **Price Alerts**: Notifications when assets cross absolute price levels
 - **Deduplication**: Won't spam you with the same alert multiple times per day
 
@@ -16,6 +16,7 @@ A Python-based investment tracker that sends daily summaries and intraday spike/
 | Gold | `GC=F` | Gold futures, converted from USD to GBP |
 | ISWD | `ISWD.L` | iShares MSCI World Islamic ETF |
 | HBKS | `HBKS.L` | HSBC Global Sukuk ETF |
+| GBP/USD | `GBPUSD=X` | Exchange rate alerts (intraday + absolute) |
 
 ## Quick Start (Raspberry Pi)
 
@@ -120,13 +121,18 @@ Edit `config.json` to customize:
         "thresholds": {
             "gold_gbp": 1.5,
             "iswd": 2.0,
-            "hbks": 2.0
+            "hbks": 2.0,
+            "gbpusd": 1.0
         }
     },
     "price_alerts": {
         "gold_gbp": {
             "above": 2200.00,
             "below": 1800.00
+        },
+        "gbpusd": {
+            "above": 1.40,
+            "below": 1.25
         }
     }
 }
@@ -135,8 +141,8 @@ Edit `config.json` to customize:
 ### Alert Thresholds
 
 - `default_threshold_pct`: Default percentage threshold for intraday alerts
-- `thresholds`: Per-asset percentage thresholds
-- `price_alerts`: Absolute price levels that trigger alerts
+- `thresholds`: Per-asset percentage thresholds (e.g. `gbpusd` defaults to 1.0% — tighter than equities since currency pairs move less)
+- `price_alerts`: Absolute price levels that trigger alerts (GBP/USD uses 4-decimal exchange rate values)
 
 ## Adding New Assets
 
@@ -191,7 +197,7 @@ Price: £23.45
 GBP/USD: 1.2650
 ```
 
-## Example Alert
+## Example Alerts
 
 ```
 Intraday Alert (14:30)
@@ -200,6 +206,15 @@ Intraday Alert (14:30)
 Current: £2,178.50
 Open: £2,145.32
 Change: +1.55% (threshold: ±1.5%)
+```
+
+```
+Intraday Alert (16:00)
+
+📉 DIP: GBP/USD
+Current: 1.2583
+Open: 1.2720
+Change: -1.08% (threshold: ±1.0%)
 ```
 
 ## Troubleshooting

--- a/config.example.json
+++ b/config.example.json
@@ -6,13 +6,18 @@
         "thresholds": {
             "gold_gbp": 1.5,
             "iswd": 2.0,
-            "hbks": 2.0
+            "hbks": 2.0,
+            "gbpusd": 1.0
         }
     },
     "price_alerts": {
         "gold_gbp": {
             "above": 2200.00,
             "below": 1800.00
+        },
+        "gbpusd": {
+            "above": 1.40,
+            "below": 1.25
         }
     }
 }

--- a/tracker.py
+++ b/tracker.py
@@ -124,8 +124,8 @@ def send_telegram_message(config: dict, message: str, logger: logging.Logger) ->
         return False
 
 
-def get_gbp_usd_rate(logger: logging.Logger) -> float | None:
-    """Fetch the current GBP/USD exchange rate."""
+def get_gbp_usd_rate(logger: logging.Logger) -> dict | None:
+    """Fetch the current GBP/USD exchange rate with open price."""
     try:
         ticker = yf.Ticker("GBPUSD=X")
         data = ticker.history(period="1d")
@@ -133,8 +133,9 @@ def get_gbp_usd_rate(logger: logging.Logger) -> float | None:
             logger.error("No data returned for GBPUSD=X")
             return None
         rate = float(data["Close"].iloc[-1])
-        logger.debug(f"GBP/USD rate: {rate}")
-        return rate
+        open_rate = float(data["Open"].iloc[-1])
+        logger.debug(f"GBP/USD rate: {rate} (open: {open_rate})")
+        return {"rate": rate, "open": open_rate}
     except Exception as e:
         logger.error(f"Failed to fetch GBP/USD rate: {e}")
         return None
@@ -335,7 +336,8 @@ def cmd_summary(config: dict, logger: logging.Logger) -> None:
     logger.info("Generating daily summary...")
 
     # Get exchange rate
-    gbp_usd_rate = get_gbp_usd_rate(logger)
+    gbp_usd_data = get_gbp_usd_rate(logger)
+    gbp_usd_rate = gbp_usd_data["rate"] if gbp_usd_data else None
     if gbp_usd_rate is None:
         logger.warning("Could not fetch exchange rate, USD assets will be skipped")
 
@@ -434,7 +436,8 @@ def cmd_watch(config: dict, logger: logging.Logger) -> None:
     alerts_to_send = []
 
     # Get exchange rate
-    gbp_usd_rate = get_gbp_usd_rate(logger)
+    gbp_usd_data = get_gbp_usd_rate(logger)
+    gbp_usd_rate = gbp_usd_data["rate"] if gbp_usd_data else None
     if gbp_usd_rate is None:
         logger.warning("Could not fetch exchange rate, USD assets will be skipped")
 
@@ -493,6 +496,55 @@ def cmd_watch(config: dict, logger: logging.Logger) -> None:
                 alerts_to_send.append(
                     f"🔔 *{asset_config['name']}* below {format_price_gbp(below)}!\n"
                     f"Current: {format_price_gbp(current)}"
+                )
+                state["fired"].append(alert_key)
+                logger.info(f"Alert triggered: {alert_key}")
+
+    # GBP/USD exchange rate alerts
+    if gbp_usd_data is not None:
+        gbp_usd_current = gbp_usd_data["rate"]
+        gbp_usd_open = gbp_usd_data["open"]
+
+        # Intraday threshold check
+        gbpusd_threshold = thresholds.get("gbpusd", 1.0)
+        if gbp_usd_open != 0:
+            gbpusd_change_pct = ((gbp_usd_current - gbp_usd_open) / gbp_usd_open) * 100
+
+            if abs(gbpusd_change_pct) >= gbpusd_threshold:
+                alert_key = f"intraday_gbpusd_{'+' if gbpusd_change_pct > 0 else '-'}"
+
+                if alert_key not in state["fired"]:
+                    direction = "📈 SPIKE" if gbpusd_change_pct > 0 else "📉 DIP"
+                    alerts_to_send.append(
+                        f"{direction}: *GBP/USD*\n"
+                        f"Current: {gbp_usd_current:.4f}\n"
+                        f"Open: {gbp_usd_open:.4f}\n"
+                        f"Change: {gbpusd_change_pct:+.2f}% (threshold: ±{gbpusd_threshold}%)"
+                    )
+                    state["fired"].append(alert_key)
+                    logger.info(f"Alert triggered: {alert_key}")
+
+        # Absolute price alerts for GBP/USD
+        gbpusd_price_alerts = price_alerts.get("gbpusd", {})
+
+        above = gbpusd_price_alerts.get("above")
+        if above is not None and gbp_usd_current >= above:
+            alert_key = "price_above_gbpusd"
+            if alert_key not in state["fired"]:
+                alerts_to_send.append(
+                    f"🔔 *GBP/USD* above {above:.4f}!\n"
+                    f"Current: {gbp_usd_current:.4f}"
+                )
+                state["fired"].append(alert_key)
+                logger.info(f"Alert triggered: {alert_key}")
+
+        below = gbpusd_price_alerts.get("below")
+        if below is not None and gbp_usd_current <= below:
+            alert_key = "price_below_gbpusd"
+            if alert_key not in state["fired"]:
+                alerts_to_send.append(
+                    f"🔔 *GBP/USD* below {below:.4f}!\n"
+                    f"Current: {gbp_usd_current:.4f}"
                 )
                 state["fired"].append(alert_key)
                 logger.info(f"Alert triggered: {alert_key}")


### PR DESCRIPTION
## Summary

- `get_gbp_usd_rate()` now returns `{rate, open}` dict instead of a plain float — no extra API call needed
- Adds GBP/USD as an alertable entity in `cmd_watch()` with intraday threshold (default 1.0%) and absolute price alerts (above/below)
- Uses 4-decimal formatting for exchange rates and the same dedup mechanism as existing asset alerts

## Test plan

- [ ] Run `python3 tracker.py -v watch` — confirm GBP/USD alert logic executes without errors
- [ ] Set `gbpusd` threshold to `0.01` in config.json, run watch, verify alert fires
- [x] Run again — verify dedup prevents duplicate alert
- [ ] Delete `data/alerts_state.json`, run again — verify alert fires after reset
- [ ] Run `python3 tracker.py summary` — verify daily summary still works
- [ ] Check `config.example.json` has the new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)