### PR TITLE
feat: add VIX market sentiment indicator to daily summary (ENG-85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Python-based investment tracker that sends daily summaries and intraday spike/
 - **Daily Summary**: Prices in GBP, daily/weekly/monthly trends
 - **Intraday Alerts**: Notifications when assets or GBP/USD move beyond configurable thresholds
 - **Price Alerts**: Notifications when assets cross absolute price levels
+- **Market Sentiment**: VIX volatility index shown in daily summary with human-readable labels (calm / normal / elevated fear / high fear)
 - **Deduplication**: Won't spam you with the same alert multiple times per day
 
 ## Tracked Assets
@@ -210,6 +211,8 @@ Brent Crude
 £57.12 / $72.30 per bbl
 🔴 -£0.85 (-1.47%)
 5d: -2.10% | 22d: +0.95%
+
+🌡️ Market Sentiment: VIX 18.3 (Normal)
 
 GBP/USD: 1.2650
 ```

--- a/tracker.py
+++ b/tracker.py
@@ -131,6 +131,40 @@ def send_telegram_message(config: dict, message: str, logger: logging.Logger) ->
         return False
 
 
+VIX_LABELS = [
+    (12, "Low volatility (calm)"),
+    (20, "Normal"),
+    (30, "Elevated fear"),
+    (float("inf"), "High fear"),
+]
+
+
+def get_vix(logger: logging.Logger) -> float | None:
+    """Fetch the current VIX level."""
+    try:
+        ticker = yf.Ticker("^VIX")
+        data = ticker.history(period="1d")
+        if data.empty:
+            logger.debug("No data returned for ^VIX")
+            return None
+        value = float(data["Close"].iloc[-1])
+        logger.debug(f"VIX: {value:.2f}")
+        return value
+    except Exception as e:
+        logger.debug(f"Failed to fetch VIX: {e}")
+        return None
+
+
+def format_vix(value: float) -> str:
+    """Format VIX value with a human-readable sentiment label."""
+    label = "Unknown"
+    for threshold, lbl in VIX_LABELS:
+        if value < threshold:
+            label = lbl
+            break
+    return f"🌡️ Market Sentiment: VIX {value:.1f} ({label})"
+
+
 def get_gbp_usd_rate(logger: logging.Logger) -> dict | None:
     """Fetch the current GBP/USD exchange rate with open price."""
     try:
@@ -410,6 +444,12 @@ def cmd_summary(config: dict, logger: logging.Logger) -> None:
                 trends.append(format_trend(monthly, "22d"))
             lines.append(f"   {' | '.join(trends)}")
 
+        lines.append("")
+
+    # VIX sentiment
+    vix = get_vix(logger)
+    if vix is not None:
+        lines.append(format_vix(vix))
         lines.append("")
 
     # Exchange rate


### PR DESCRIPTION
## Summary
- Adds VIX (`^VIX`) sentiment line to the daily summary between asset prices and GBP/USD rate
- Labels: Low volatility (calm) <12, Normal 12-20, Elevated fear 20-30, High fear 30+
- Gracefully skipped when data is unavailable — no config changes needed
- README updated with feature description and example output

## Test plan
- [ ] `python3 tracker.py -v summary` includes VIX line with correct label
- [ ] Verify VIX line appears after asset prices and before GBP/USD rate
- [ ] Disconnect network / mock failure — verify summary still sends without VIX line

🤖 Generated with [Claude Code](https://claude.com/claude-code)