### PR TITLE
feat: add standalone cron installer script (ENG-87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,27 @@ python3 tracker.py test
 # Set up cron jobs manually (see below)
 ```
 
-### Manual Cron Setup
+### Cron Setup
 
-Edit your crontab with `crontab -e` and add:
+Run the standalone cron installer (idempotent — safe to re-run anytime):
 
-```cron
-# Daily summary at 8:00 AM (Mon-Fri)
-0 8 * * 1-5 cd /path/to/daily-price-tracker && python3 tracker.py summary >> logs/cron.log 2>&1
-
-# Intraday watch every 15 min during market hours (Mon-Fri)
-*/15 8-17 * * 1-5 cd /path/to/daily-price-tracker && python3 tracker.py watch >> logs/cron.log 2>&1
-
-# Weekly digest at 6:00 PM on Friday
-0 18 * * 5 cd /path/to/daily-price-tracker && python3 tracker.py digest >> logs/cron.log 2>&1
+```bash
+./install_crons.sh
 ```
+
+This installs:
+- Daily summary at 8:00 AM (Mon-Fri)
+- Intraday watch every 15 min, 8AM-5PM (Mon-Fri)
+- Weekly digest at 6:00 PM Friday
+
+### Updating After `git pull`
+
+```bash
+git pull
+./install_crons.sh
+```
+
+This ensures any new or changed cron jobs are picked up automatically.
 
 ## Usage
 
@@ -318,7 +325,8 @@ daily-price-tracker/
 ├── config.json             # Your configuration (gitignored)
 ├── config.example.json     # Template configuration
 ├── requirements.txt        # Python dependencies
-├── setup_pi.sh             # Setup script
+├── setup_pi.sh             # First-time setup script
+├── install_crons.sh        # Idempotent cron job installer
 ├── .gitignore
 ├── README.md
 ├── data/

--- a/install_crons.sh
+++ b/install_crons.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Daily Price Tracker - Cron Job Installer
+#
+# Idempotently installs all required cron jobs.
+# Safe to re-run after every git pull — removes old entries first,
+# so running it multiple times never creates duplicates.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRACKER_PATH="$SCRIPT_DIR/tracker.py"
+CRON_TAG="# daily-price-tracker"
+
+# Use venv Python if available, fall back to system python3
+VENV_PYTHON="$SCRIPT_DIR/venv/bin/python3"
+if [ -x "$VENV_PYTHON" ]; then
+    PYTHON_PATH="$VENV_PYTHON"
+else
+    PYTHON_PATH=$(which python3)
+fi
+
+echo "Installing cron jobs for Daily Price Tracker..."
+echo "  Repo: $SCRIPT_DIR"
+echo "  Python: $PYTHON_PATH"
+echo
+
+# Remove any existing tracker cron entries, then add fresh ones
+crontab -l 2>/dev/null | grep -v "$CRON_TAG" > /tmp/crontab_tracker.tmp || true
+
+cat >> /tmp/crontab_tracker.tmp << EOF
+0 8 * * 1-5 cd $SCRIPT_DIR && $PYTHON_PATH $TRACKER_PATH summary >> $SCRIPT_DIR/logs/cron.log 2>&1 $CRON_TAG
+*/15 8-17 * * 1-5 cd $SCRIPT_DIR && $PYTHON_PATH $TRACKER_PATH watch >> $SCRIPT_DIR/logs/cron.log 2>&1 $CRON_TAG
+0 18 * * 5 cd $SCRIPT_DIR && $PYTHON_PATH $TRACKER_PATH digest >> $SCRIPT_DIR/logs/cron.log 2>&1 $CRON_TAG
+EOF
+
+crontab /tmp/crontab_tracker.tmp
+rm /tmp/crontab_tracker.tmp
+
+echo "Cron jobs installed:"
+echo "  - Daily summary:   8:00 AM Mon-Fri"
+echo "  - Intraday watch:  Every 15 min, 8AM-5PM Mon-Fri"
+echo "  - Weekly digest:   6:00 PM Friday"
+echo
+echo "Verify with: crontab -l"

--- a/setup_pi.sh
+++ b/setup_pi.sh
@@ -119,31 +119,7 @@ echo "  Setting up Cron Jobs"
 echo "========================================"
 echo
 
-# Get absolute path to tracker.py
-TRACKER_PATH="$SCRIPT_DIR/tracker.py"
-PYTHON_PATH=$(which python3)
-
-# Remove any existing tracker cron jobs
-crontab -l 2>/dev/null | grep -v "daily-price-tracker" | grep -v "$TRACKER_PATH" > /tmp/crontab.tmp || true
-
-# Add new cron jobs
-# Daily summary at 8:00 AM London time (weekdays)
-echo "0 8 * * 1-5 cd $SCRIPT_DIR && $PYTHON_PATH $TRACKER_PATH summary >> $SCRIPT_DIR/logs/cron.log 2>&1 # daily-price-tracker" >> /tmp/crontab.tmp
-
-# Intraday watch every 15 minutes during market hours (8-17, weekdays)
-echo "*/15 8-17 * * 1-5 cd $SCRIPT_DIR && $PYTHON_PATH $TRACKER_PATH watch >> $SCRIPT_DIR/logs/cron.log 2>&1 # daily-price-tracker" >> /tmp/crontab.tmp
-
-# Install new crontab
-crontab /tmp/crontab.tmp
-rm /tmp/crontab.tmp
-
-echo "Cron jobs installed:"
-echo "  - Daily summary: 8:00 AM (Mon-Fri)"
-echo "  - Intraday watch: Every 15 min, 8AM-5PM (Mon-Fri)"
-echo
-echo "To view cron jobs: crontab -l"
-echo "To edit cron jobs: crontab -e"
-echo
+"$SCRIPT_DIR/install_crons.sh"
 
 echo "========================================"
 echo "  Setup Complete!"


### PR DESCRIPTION
## Summary
- Adds `install_crons.sh` — standalone, idempotent cron job installer
- Uses venv Python (`venv/bin/python3`) when available, falls back to system `python3`
- Tags all entries with `# daily-price-tracker` for clean removal on re-run
- Installs all three cron jobs: daily summary, intraday watch, weekly digest
- `setup_pi.sh` now delegates cron setup to `install_crons.sh` (no duplicated logic)
- README updated: new "Updating After `git pull`" workflow, file structure entry

## Test plan
- [ ] `./install_crons.sh` installs all 3 cron jobs — verify with `crontab -l`
- [ ] Run `./install_crons.sh` twice — verify no duplicate entries
- [ ] `./setup_pi.sh` still completes full setup including cron installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)