### PR TITLE
feat: add multi-subscriber support for Telegram alerts (ENG-88)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,14 @@ python3 tracker.py summary   # Daily price summary
 python3 tracker.py watch     # Intraday spike/dip alerts
 python3 tracker.py digest    # Weekly digest (Friday)
 python3 tracker.py test      # Test Telegram connection
+python3 subscribe.py         # Persistent listener for /subscribe commands
 ```
 
 ## Project Structure
 
 ```
 tracker.py              # Main script — all logic lives here
+subscribe.py            # Persistent polling listener for /subscribe commands
 config.json             # User config with Telegram creds + thresholds (gitignored)
 config.example.json     # Template config (committed)
 install_crons.sh        # Idempotent cron installer (uses venv Python)
@@ -40,6 +42,7 @@ requirements.txt        # Python dependencies
 data/                   # Runtime data (gitignored)
   price_history.json    # 90-day rolling price history
   alerts_state.json     # Today's fired alerts
+  subscribers.json      # Subscriber chat IDs (auto-populated)
 logs/                   # Log files (gitignored)
 ```
 
@@ -53,7 +56,7 @@ logs/                   # Log files (gitignored)
 
 ## Architecture Notes
 
-- Single-file architecture — all logic is in `tracker.py`
+- Main logic lives in `tracker.py`; `subscribe.py` is a separate long-running listener
 - `ASSETS` dict defines tracked assets with ticker, currency, and display config
 - LSE tickers (`.L`) have smart pence-to-pounds detection (threshold > 100)
 - Alert deduplication: each alert type fires once per direction per day via `alerts_state.json`
@@ -75,6 +78,7 @@ Runs on a Raspberry Pi with:
 - Python venv at `~/daily-price-tracker/venv/` (PEP 668 enforced on Pi OS)
 - Cron jobs installed via `./install_crons.sh` (tagged with `# daily-price-tracker`)
 - Three cron schedules: daily summary (8am), intraday watch (every 15min), weekly digest (6pm Friday)
+- `subscribe.py` runs in a dedicated tmux pane: `tmux new -d -s subscribe 'python3 subscribe.py'`
 
 ## Testing
 
@@ -82,6 +86,7 @@ Runs on a Raspberry Pi with:
 - `python3 tracker.py -v summary` — verbose mode for debugging
 - Temporarily lower thresholds to test alert firing
 - Check `logs/tracker.log` for application logs, `logs/cron.log` for cron output
+- Check `logs/subscribe.log` for subscription listener logs
 
 ## Important Conventions
 
@@ -89,4 +94,5 @@ Runs on a Raspberry Pi with:
 - `config.json` is gitignored and must stay that way
 - All prices are displayed in both GBP and USD
 - Telegram messages use Markdown formatting
-- Keep the single-file architecture unless there's a strong reason to split
+- `send_telegram_message()` fans out to all subscribers in `data/subscribers.json`, falling back to config `telegram_chat_id`
+- `subscribe.py` is intentionally separate — it's a long-running process, not a cron job

--- a/subscribe.py
+++ b/subscribe.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Telegram Subscription Listener
+
+Long-polls the Telegram Bot API for /subscribe and /unsubscribe commands.
+Manages subscriber list in data/subscribers.json.
+
+Usage:
+    python3 subscribe.py          # Run in foreground
+    tmux new -d -s subscribe 'python3 subscribe.py'  # Run in tmux
+"""
+
+import json
+import logging
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pytz
+import requests
+
+# Project paths (same as tracker.py)
+PROJECT_DIR = Path(__file__).parent.resolve()
+CONFIG_PATH = PROJECT_DIR / "config.json"
+DATA_DIR = PROJECT_DIR / "data"
+LOGS_DIR = PROJECT_DIR / "logs"
+SUBSCRIBERS_PATH = DATA_DIR / "subscribers.json"
+LOG_PATH = LOGS_DIR / "subscribe.log"
+
+LONDON_TZ = pytz.timezone("Europe/London")
+
+# Long polling timeout (seconds)
+POLL_TIMEOUT = 60
+
+
+def setup_logging() -> logging.Logger:
+    """Configure logging to file and stdout."""
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
+
+    logger = logging.getLogger("subscribe")
+    logger.setLevel(logging.DEBUG)
+
+    file_handler = logging.FileHandler(LOG_PATH)
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(file_handler)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    console_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    logger.addHandler(console_handler)
+
+    return logger
+
+
+def load_config() -> dict:
+    """Load configuration from config.json."""
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError(
+            f"Config file not found: {CONFIG_PATH}\n"
+            "Run setup_pi.sh or copy config.example.json to config.json"
+        )
+
+    with open(CONFIG_PATH) as f:
+        return json.load(f)
+
+
+def load_subscribers() -> list[str]:
+    """Load subscriber chat IDs from subscribers.json."""
+    if not SUBSCRIBERS_PATH.exists():
+        return []
+
+    with open(SUBSCRIBERS_PATH) as f:
+        data = json.load(f)
+
+    return data.get("subscribers", [])
+
+
+def save_subscribers(chat_ids: list[str]) -> None:
+    """Save subscriber chat IDs to subscribers.json."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    with open(SUBSCRIBERS_PATH, "w") as f:
+        json.dump({"subscribers": chat_ids}, f, indent=2)
+
+
+def send_reply(token: str, chat_id: str, text: str, logger: logging.Logger) -> None:
+    """Send a reply to a specific chat."""
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = {
+        "chat_id": chat_id,
+        "text": text,
+        "parse_mode": "Markdown",
+    }
+
+    try:
+        response = requests.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.error(f"Failed to send reply to {chat_id}: {e}")
+
+
+def poll_updates(token: str, offset: int, logger: logging.Logger) -> tuple[list, int]:
+    """Long-poll for new updates from Telegram."""
+    url = f"https://api.telegram.org/bot{token}/getUpdates"
+    params = {
+        "offset": offset,
+        "timeout": POLL_TIMEOUT,
+        "allowed_updates": '["message"]',
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=POLL_TIMEOUT + 10)
+        response.raise_for_status()
+        data = response.json()
+
+        if not data.get("ok"):
+            logger.error(f"Telegram API error: {data}")
+            return [], offset
+
+        updates = data.get("result", [])
+        if updates:
+            offset = updates[-1]["update_id"] + 1
+
+        return updates, offset
+
+    except requests.RequestException as e:
+        logger.error(f"Polling error: {e}")
+        return [], offset
+
+
+def handle_update(update: dict, token: str, logger: logging.Logger) -> None:
+    """Process a single update from Telegram."""
+    message = update.get("message")
+    if not message:
+        return
+
+    text = message.get("text", "").strip()
+    chat_id = str(message["chat"]["id"])
+    user = message.get("from", {})
+    username = user.get("username", "unknown")
+
+    if text == "/subscribe":
+        subscribers = load_subscribers()
+
+        if chat_id in subscribers:
+            send_reply(token, chat_id, "You're already subscribed.", logger)
+            logger.info(f"Already subscribed: {username} ({chat_id})")
+            return
+
+        subscribers.append(chat_id)
+        save_subscribers(subscribers)
+
+        now = datetime.now(LONDON_TZ).strftime("%H:%M %d %b %Y")
+        send_reply(
+            token, chat_id,
+            f"*Subscribed!* You'll now receive daily price summaries "
+            f"and intraday alerts.\n\n_Subscribed at {now}_",
+            logger,
+        )
+        logger.info(f"New subscriber: {username} ({chat_id}) — total: {len(subscribers)}")
+
+    elif text == "/unsubscribe":
+        subscribers = load_subscribers()
+
+        if chat_id not in subscribers:
+            send_reply(token, chat_id, "You're not currently subscribed.", logger)
+            logger.info(f"Not subscribed: {username} ({chat_id})")
+            return
+
+        subscribers.remove(chat_id)
+        save_subscribers(subscribers)
+
+        send_reply(
+            token, chat_id,
+            "You've been unsubscribed. Send /subscribe to re-subscribe.",
+            logger,
+        )
+        logger.info(f"Unsubscribed: {username} ({chat_id}) — total: {len(subscribers)}")
+
+
+def main() -> None:
+    """Main polling loop."""
+    logger = setup_logging()
+
+    try:
+        config = load_config()
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+    token = config["telegram_bot_token"]
+    offset = 0
+
+    logger.info("Subscription listener started — waiting for /subscribe commands...")
+
+    while True:
+        try:
+            updates, offset = poll_updates(token, offset, logger)
+
+            for update in updates:
+                handle_update(update, token, logger)
+
+        except KeyboardInterrupt:
+            logger.info("Shutting down subscription listener")
+            break
+        except Exception as e:
+            logger.exception(f"Unexpected error: {e}")
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/tracker.py
+++ b/tracker.py
@@ -25,6 +25,7 @@ DATA_DIR = PROJECT_DIR / "data"
 LOGS_DIR = PROJECT_DIR / "logs"
 HISTORY_PATH = DATA_DIR / "price_history.json"
 ALERTS_STATE_PATH = DATA_DIR / "alerts_state.json"
+SUBSCRIBERS_PATH = DATA_DIR / "subscribers.json"
 LOG_PATH = LOGS_DIR / "tracker.log"
 
 # Timezone
@@ -109,26 +110,57 @@ def load_config() -> dict:
         return json.load(f)
 
 
+def load_subscribers() -> list[str]:
+    """Load subscriber chat IDs from subscribers.json."""
+    if not SUBSCRIBERS_PATH.exists():
+        return []
+
+    with open(SUBSCRIBERS_PATH) as f:
+        data = json.load(f)
+
+    return data.get("subscribers", [])
+
+
+def save_subscribers(chat_ids: list[str]) -> None:
+    """Save subscriber chat IDs to subscribers.json."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    with open(SUBSCRIBERS_PATH, "w") as f:
+        json.dump({"subscribers": chat_ids}, f, indent=2)
+
+
 def send_telegram_message(config: dict, message: str, logger: logging.Logger) -> bool:
-    """Send a message via Telegram bot API."""
+    """Send a message to all subscribers via Telegram bot API.
+
+    Sends to all chat IDs in subscribers.json, falling back to
+    config telegram_chat_id if no subscribers exist.
+    """
     token = config["telegram_bot_token"]
-    chat_id = config["telegram_chat_id"]
+
+    # Build recipient list: subscribers with fallback to config chat_id
+    subscribers = load_subscribers()
+    if not subscribers:
+        subscribers = [str(config["telegram_chat_id"])]
 
     url = f"https://api.telegram.org/bot{token}/sendMessage"
-    payload = {
-        "chat_id": chat_id,
-        "text": message,
-        "parse_mode": "Markdown",
-    }
+    all_ok = True
 
-    try:
-        response = requests.post(url, json=payload, timeout=30)
-        response.raise_for_status()
-        logger.info("Telegram message sent successfully")
-        return True
-    except requests.RequestException as e:
-        logger.error(f"Failed to send Telegram message: {e}")
-        return False
+    for chat_id in subscribers:
+        payload = {
+            "chat_id": chat_id,
+            "text": message,
+            "parse_mode": "Markdown",
+        }
+
+        try:
+            response = requests.post(url, json=payload, timeout=30)
+            response.raise_for_status()
+            logger.info(f"Telegram message sent to {chat_id}")
+        except requests.RequestException as e:
+            logger.error(f"Failed to send Telegram message to {chat_id}: {e}")
+            all_ok = False
+
+    return all_ok
 
 
 VIX_LABELS = [


### PR DESCRIPTION
## Summary

- Add `/subscribe` and `/unsubscribe` bot commands via `subscribe.py` (long-polling listener)
- Update `send_telegram_message()` to fan out to all subscribers in `data/subscribers.json`, with fallback to config `telegram_chat_id`
- Update `CLAUDE.md` with new file structure and deployment notes

## How it works

- `subscribe.py` runs as a persistent process (tmux on the Pi) and listens for `/subscribe` / `/unsubscribe` messages
- Subscriber chat IDs are stored in `data/subscribers.json` (gitignored, auto-populated)
- All existing alert/summary/digest commands automatically send to all subscribers — no config changes needed

## Test plan

- [x] Run `python3 subscribe.py` and send `/subscribe` to the bot
- [x] Verify confirmation message is received
- [x] Run `python3 tracker.py test` and confirm message is received by the subscriber
- [x] Send `/unsubscribe` and verify messages stop
- [x] Delete `data/subscribers.json` and verify fallback to config `telegram_chat_id` works

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)