### PR TITLE
ENG-260: Add a --dry-run flag to tracker.py (print summary instead of sending to Telegram)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ python3 tracker.py test
 
 # Verbose output
 python3 tracker.py -v summary
+
+# Dry run — print message to stdout without sending to Telegram
+python3 tracker.py --dry-run summary
 ```
 
 ## Configuration

--- a/tracker.py
+++ b/tracker.py
@@ -404,7 +404,7 @@ def format_trend(trend: float | None, label: str) -> str:
     return f"{label}: {sign}{trend:.2f}%"
 
 
-def cmd_summary(config: dict, logger: logging.Logger) -> None:
+def cmd_summary(config: dict, logger: logging.Logger, dry_run: bool = False) -> None:
     """Generate and send daily summary."""
     logger.info("Generating daily summary...")
 
@@ -503,10 +503,14 @@ def cmd_summary(config: dict, logger: logging.Logger) -> None:
     # Send message
     message = "\n".join(lines)
     logger.debug(f"Summary message:\n{message}")
-    send_telegram_message(config, message, logger)
+    if dry_run:
+        print("=== DRY RUN — not sending to Telegram ===")
+        print(message)
+    else:
+        send_telegram_message(config, message, logger)
 
 
-def cmd_watch(config: dict, logger: logging.Logger) -> None:
+def cmd_watch(config: dict, logger: logging.Logger, dry_run: bool = False) -> None:
     """Check for intraday spikes/dips and price alerts."""
     logger.info("Running intraday watch...")
 
@@ -636,7 +640,11 @@ def cmd_watch(config: dict, logger: logging.Logger) -> None:
         now = datetime.now(LONDON_TZ).strftime("%H:%M")
         header = f"*Intraday Alert* ({now})\n\n"
         message = header + "\n\n".join(alerts_to_send)
-        send_telegram_message(config, message, logger)
+        if dry_run:
+            print("=== DRY RUN — not sending to Telegram ===")
+            print(message)
+        else:
+            send_telegram_message(config, message, logger)
     else:
         logger.info("No new alerts to send")
 
@@ -690,7 +698,7 @@ def _alert_key_to_human(alert_key: str) -> tuple[str, str]:
     return ("🔔", f"{name} {word}")
 
 
-def cmd_digest(config: dict, logger: logging.Logger) -> None:
+def cmd_digest(config: dict, logger: logging.Logger, dry_run: bool = False) -> None:
     """Generate and send weekly digest summary."""
     logger.info("Generating weekly digest...")
 
@@ -811,10 +819,14 @@ def cmd_digest(config: dict, logger: logging.Logger) -> None:
 
     message = "\n".join(lines)
     logger.debug(f"Digest message:\n{message}")
-    send_telegram_message(config, message, logger)
+    if dry_run:
+        print("=== DRY RUN — not sending to Telegram ===")
+        print(message)
+    else:
+        send_telegram_message(config, message, logger)
 
 
-def cmd_test(config: dict, logger: logging.Logger) -> None:
+def cmd_test(config: dict, logger: logging.Logger, dry_run: bool = False) -> None:
     """Send a test message to verify Telegram configuration."""
     logger.info("Sending test message...")
 
@@ -824,7 +836,10 @@ def cmd_test(config: dict, logger: logging.Logger) -> None:
         f"_Sent at {datetime.now(LONDON_TZ).strftime('%Y-%m-%d %H:%M:%S')} London time_"
     )
 
-    if send_telegram_message(config, message, logger):
+    if dry_run:
+        print("=== DRY RUN — not sending to Telegram ===")
+        print(message)
+    elif send_telegram_message(config, message, logger):
         print("Test message sent successfully!")
     else:
         print("Failed to send test message. Check logs for details.")
@@ -841,6 +856,11 @@ def main() -> None:
         "-v", "--verbose",
         action="store_true",
         help="Enable verbose output",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print messages to stdout instead of sending to Telegram",
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
@@ -877,7 +897,7 @@ def main() -> None:
     }
 
     try:
-        commands[args.command](config, logger)
+        commands[args.command](config, logger, dry_run=args.dry_run)
     except Exception as e:
         logger.exception(f"Command '{args.command}' failed: {e}")
         sys.exit(1)


### PR DESCRIPTION
## ENG-260: Add a --dry-run flag to tracker.py (print summary instead of sending to Telegram)

**Ticket:** https://linear.app/amazz/issue/ENG-260/add-a-dry-run-flag-to-trackerpy-print-summary-instead-of-sending-to

## What was implemented

Added `--dry-run` CLI flag to `tracker.py`. When passed, all commands (`summary`, `watch`, `digest`, `test`) print a `=== DRY RUN — not sending to Telegram ===` marker followed by the fully-formatted message to stdout, instead of calling `send_telegram_message()`. All price-fetching, formatting, and history-saving logic remains identical — only the final delivery step is swapped.

Changes:
- **`tracker.py`**: Added `--dry-run` argument to the top-level argparse parser. Added `dry_run=False` parameter to `cmd_summary`, `cmd_watch`, `cmd_digest`, and `cmd_test`. Each function checks the flag before the send step and prints to stdout when enabled. Updated the command dispatch to pass `dry_run=args.dry_run`.
- **`README.md`**: Documented `--dry-run` in the Usage section.

No new dependencies. No existing tests or linter config in the project.

---

✅ Passed **Multi-model review** (Gemini `gemini-2.5-flash` via `api`)

The changes correctly implement the `--dry-run` flag as specified in the ticket. The flag is properly parsed, the message is printed to stdout with the required marker line, and the README is updated. All acceptance criteria are met.
---

*Implemented by [Noctra](https://github.com/ahmadAlMezaal/noctra) 🌙 using Claude Code*
<!-- noctra-authored -->