### PR TITLE
feat: track ISDE, drop HBKS (ENG-364, ENG-365)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Daily Price Tracker — a Python-based investment tracker that sends daily summa
 ## Tracked Assets
 
 - **Gold** (`GC=F`) — USD-native, converted to GBP
-- **ISWD** (`ISWD.L`) — iShares MSCI World Islamic ETF, GBP-native
-- **HBKS** (`HBKS.L`) — HSBC Global Sukuk ETF, GBP-native
+- **ISWD** (`ISWD.L`) — iShares MSCI World Islamic ETF, GBP-native (quoted in pence)
+- **ISDE** (`ISDE.L`) — iShares MSCI EM Islamic ETF, USD-native despite the `.L` suffix
 - **Brent Crude** (`BZ=F`) — USD-native, converted to GBP
 - **GBP/USD** (`GBPUSD=X`) — exchange rate alerts
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Daily Price Tracker
 
-A Python-based investment tracker that sends daily summaries and intraday spike/dip alerts for Gold, Brent Crude, ISWD, HBKS, and GBP/USD via Telegram. Designed to run on a Raspberry Pi via cron.
+A Python-based investment tracker that sends daily summaries and intraday spike/dip alerts for Gold, Brent Crude, ISWD, ISDE, and GBP/USD via Telegram. Designed to run on a Raspberry Pi via cron.
 
 ## Features
 
@@ -15,8 +15,8 @@ A Python-based investment tracker that sends daily summaries and intraday spike/
 | Asset | Ticker | Description |
 |-------|--------|-------------|
 | Gold | `GC=F` | Gold futures, converted from USD to GBP |
-| ISWD | `ISWD.L` | iShares MSCI World Islamic ETF |
-| HBKS | `HBKS.L` | HSBC Global Sukuk ETF |
+| ISWD | `ISWD.L` | iShares MSCI World Islamic ETF, quoted in pence |
+| ISDE | `ISDE.L` | iShares MSCI EM Islamic ETF, quoted in USD and converted to GBP |
 | Brent Crude | `BZ=F` | Brent Crude Oil futures, converted from USD to GBP |
 | GBP/USD | `GBPUSD=X` | Exchange rate alerts (intraday + absolute) |
 
@@ -139,7 +139,7 @@ Edit `config.json` to customize:
         "thresholds": {
             "gold_gbp": 1.5,
             "iswd": 2.0,
-            "hbks": 2.0,
+            "isde": 2.0,
             "brent": 2.5,
             "gbpusd": 1.0
         }
@@ -175,13 +175,23 @@ Edit `tracker.py` and add to the `ASSETS` dictionary:
 ASSETS = {
     # ... existing assets ...
     "new_asset": {
-        "ticker": "TICKER.L",      # Yahoo Finance ticker
+        "ticker": "TICKER.L",       # Yahoo Finance ticker
         "name": "Display Name",     # Name shown in messages
-        "currency": "GBP",          # Native currency
-        "convert_to_gbp": False,    # True if needs USD→GBP conversion
-        "pence_to_pounds": True,    # True if quoted in pence
+        "emoji": "📈",              # Emoji shown beside the name
+        "native_currency": "GBP",   # "GBP" or "USD" — USD assets are converted to GBP
+        "unit": "",                 # Optional suffix, e.g. "per oz"
     },
 }
+```
+
+`native_currency` must match the currency the ticker is actually **quoted** in, not the
+fund's base currency. LSE (`.L`) tickers quoted in GBP are auto-detected as pence and
+divided by 100 when the raw value exceeds `PENCE_THRESHOLD`; USD-quoted `.L` tickers
+such as `ISDE.L` skip that conversion entirely. Check with:
+
+```python
+import yfinance as yf
+yf.Ticker("TICKER.L").info["currency"]   # "GBp" = pence, "GBP" = pounds, "USD" = dollars
 ```
 
 Then add thresholds in `config.json`:
@@ -212,9 +222,9 @@ Price: £5.67
 🔴 -£0.03 (-0.53%)
 5d: -0.12% | 22d: +2.10%
 
-HBKS
-Price: £23.45
-🟢 +£0.15 (+0.64%)
+ISDE
+£25.18 / $34.00
+🟢 +£0.16 (+0.64%)
 5d: +0.89% | 22d: +1.56%
 
 Brent Crude

--- a/config.example.json
+++ b/config.example.json
@@ -6,7 +6,7 @@
         "thresholds": {
             "gold_gbp": 1.5,
             "iswd": 2.0,
-            "hbks": 2.0,
+            "isde": 2.0,
             "brent": 2.5,
             "gbpusd": 1.0
         }

--- a/setup_pi.sh
+++ b/setup_pi.sh
@@ -75,7 +75,7 @@ if [ "$SKIP_CONFIG" != "true" ]; then
         "thresholds": {
             "gold_gbp": 1.5,
             "iswd": 2.0,
-            "hbks": 2.0
+            "isde": 2.0
         }
     },
     "price_alerts": {

--- a/tracker.py
+++ b/tracker.py
@@ -2,7 +2,7 @@
 """
 Daily Investment Price Tracker
 
-Tracks gold (GC=F), ISWD.L, and HBKS.L prices.
+Tracks gold (GC=F), ISWD.L, ISDE.L, and Brent Crude (BZ=F) prices.
 Sends daily summaries and intraday spike/dip alerts via Telegram.
 """
 
@@ -47,11 +47,12 @@ ASSETS = {
         "native_currency": "GBP",
         "unit": "",
     },
-    "hbks": {
-        "ticker": "HBKS.L",
-        "name": "HBKS",
-        "emoji": "📊",
-        "native_currency": "GBP",
+    "isde": {
+        "ticker": "ISDE.L",
+        "name": "ISDE",
+        "emoji": "🌍",
+        # ISDE.L is quoted in USD on the LSE, unlike the pence-quoted ISWD.L
+        "native_currency": "USD",
         "unit": "",
     },
     "brent": {
@@ -63,7 +64,7 @@ ASSETS = {
     },
 }
 
-# LSE tickers that are known to be quoted in pence (not pounds)
+# GBP-quoted LSE tickers may be priced in pence rather than pounds
 # If raw value > 100, assume pence and divide by 100
 PENCE_THRESHOLD = 100
 
@@ -244,9 +245,15 @@ def get_asset_price(
         else:
             prev_close_raw = open_raw
 
-        # Smart pence detection for LSE tickers
-        # If the ticker ends in .L and raw value > 100, it's likely in pence
-        if ticker_symbol.endswith(".L") and current_raw > PENCE_THRESHOLD:
+        # Smart pence detection for GBP-quoted LSE tickers
+        # If the ticker ends in .L and raw value > 100, it's likely in pence.
+        # USD-quoted LSE tickers (e.g. ISDE.L) are never pence, so they are
+        # excluded — otherwise they'd be silently divided by 100 above $100.
+        if (
+            ticker_symbol.endswith(".L")
+            and native_currency == "GBP"
+            and current_raw > PENCE_THRESHOLD
+        ):
             logger.debug(f"{ticker_symbol} raw value {current_raw} > {PENCE_THRESHOLD}, converting from pence to pounds")
             current_raw = current_raw / 100
             open_raw = open_raw / 100


### PR DESCRIPTION
## Summary

Adds **ISDE** (`ISDE.L`, iShares MSCI EM Islamic UCITS ETF) as a tracked asset and removes **HBKS** (`HBKS.L`, HSBC Global Sukuk ETF), which is no longer held. Shipped together because both changes touch the same lines of the same files.

**Tickets:**
- [ENG-364 — Add ISDE as a tracked asset](https://linear.app/amazz/issue/ENG-364/add-isde-ishares-msci-em-islamic-etf-as-a-tracked-asset)
- [ENG-365 — Remove HBKS from tracked assets](https://linear.app/amazz/issue/ENG-365/remove-hbks-hsbc-global-sukuk-etf-from-tracked-assets)

## The quote-currency wrinkle

ISDE.L is quoted in **USD** on the LSE, unlike the other `.L` tickers:

| Ticker | Quote currency | Raw close |
| --- | --- | --- |
| `ISWD.L` | GBp (pence) | 4856 → £48.56 |
| `HBKS.L` (removed) | GBP (pounds) | 8.56 |
| `ISDE.L` (new) | **USD** | 34.00 |

So ISDE is configured as `native_currency: "USD"` and reuses the existing USD→GBP conversion path.

That makes it the first USD-quoted `.L` ticker in the project, which breaks an assumption in the pence heuristic. `get_asset_price()` previously divided by 100 for **any** `.L` ticker whose raw value exceeded `PENCE_THRESHOLD` (100) — safe while every `.L` ticker was GBP-denominated. Left alone, ISDE would be silently divided by 100 the moment it traded above \$100. Pence detection is now gated on `native_currency == "GBP"`.

This is a latent-bug fix rather than an observed one: at \$34 ISDE is nowhere near the threshold today.

## Changes

- **`tracker.py`** — swap the `hbks` entry for `isde` in `ASSETS`; gate pence detection on `native_currency == "GBP"`; update the module docstring.
- **`config.example.json`** / **`setup_pi.sh`** — replace the `hbks` intraday threshold with `isde` at 2.0%, matching the other ETFs.
- **`README.md`** / **`CLAUDE.md`** — update tracked-asset lists and example summary output. Also refreshes the stale "Adding New Assets" section, which documented `currency` / `convert_to_gbp` / `pence_to_pounds` keys that no longer exist in the `ASSETS` schema, and adds a note on checking a ticker's quote currency.

## Verification

`python3 tracker.py --dry-run summary` (using the `--dry-run` flag from #56):

```
🥇 *Gold*
   £3,056.03 / $4,070.80 per oz
   🟢 +£13.06 (+0.43%)

📈 *ISWD*
   £48.56 / $64.68
   🔴 £-0.10 (-0.21%)

🌍 *ISDE*
   £25.52 / $34.00
   🔴 £-0.34 (-1.31%)

🛢️ *Brent Crude*
   £72.65 / $96.78 per bbl
   🔴 £-3.10 (-4.09%)
```

- ISDE resolves to £25.52 / \$34.00 at GBP/USD 1.3321 — correct.
- ISWD still £48.56, so the pence path is unaffected by the refactor.
- HBKS no longer appears; `watch` and `digest` both run clean.
- ISDE shows no 5d/22d trends yet because it has no price history; these populate from the first scheduled run onwards.

## Deployment notes

- Standard deploy: `git pull && ./install_crons.sh`.
- The live `config.json` on the Pi needs `"isde": 2.0` adding under `intraday_alerts.thresholds`. Not strictly required — `default_threshold_pct` is already 2.0, so ISDE gets the same value either way. The stale `hbks` key can be left in place harmlessly.
- Runtime data is deliberately untouched: `data/price_history.json` keeps its historical `hbks` entries and `data/alerts_state.json` may hold stale `hbks` alert keys. Both are gitignored and simply stop being read, since the summary and digest iterate the `ASSETS` dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)